### PR TITLE
Use a constructor as a value for type

### DIFF
--- a/deps/instance.js
+++ b/deps/instance.js
@@ -1,0 +1,13 @@
+
+/**
+ * Improved instanceof
+ */
+module.exports = function instance (obj, type) {
+  switch (typeof obj) {
+    case 'undefined': return false;
+    case 'null': return false;
+    case 'object': return obj instanceof type;
+  }
+  // compare constructor of primitive
+  return obj.constructor == type;
+}

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -1,0 +1,13 @@
+var is = require('../deps/instance');
+
+module.exports = function instance(attr, type) {
+  return function(Model){
+    if ('function' !== typeof type) return;
+    Model.validate(function(model){
+      var val = model.attrs[attr];
+
+      if(val !== undefined && !is(val, type))
+        model.error(attr, "should be a " + type.name);
+    });
+  };
+};

--- a/lib/type.js
+++ b/lib/type.js
@@ -2,9 +2,10 @@ var typeCheck = require('../deps/type');
 
 module.exports = function type(attr, type) {
   return function(Model){
+    if ('string' !== typeof type) return;
     Model.validate(function(model){
       var val = model.attrs[attr];
-      if(val != undefined && typeCheck(val) !== type)
+      if(val !== undefined && typeCheck(val) !== type)
         model.error(attr, "should be a " + type);
     });
   };

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,4 +1,5 @@
 required = require('./required');
+instance = require('./instance');
 type = require('./type');
 format = require('./format');
 confirms = require('./confirms');
@@ -23,6 +24,7 @@ function checkValidationsForAttr(attr) {
 
   // Type Checking
   if (modelAttr.type) {
+    this.use(instance(attr, this.attrs[attr].type));
     this.use(type(attr, this.attrs[attr].type));
   }
 

--- a/test/validator_test.js
+++ b/test/validator_test.js
@@ -98,6 +98,43 @@ describe("type", function() {
   });
 });
 
+describe("instance", function() {
+  var Phone = modella('phone');
+  var InstanceUser = modella('user')
+    .attr('email', { type: String })
+    .attr('phone', { type: Phone });
+  InstanceUser.use(validators);
+
+  it("detects model fields", function () {
+    var user = new InstanceUser({phone: new Phone()});
+    // user.validate()
+    expect(user.isValid()).to.be(true);
+  });
+
+  it("breaks #isValid() if the field is the wrong type", function () {
+    var user = new InstanceUser({email: 123});
+    expect(user.isValid()).to.be(false);
+  });
+
+  it("populates #errors() if the field is the wrong type", function() {
+    var user = new InstanceUser({email: 123});
+    user.validate();
+    expect(user.errors).to.have.length(1);
+    expect(user.errors[0]).to.have.property('attr', 'email');
+    expect(user.errors[0]).to.have.property('message', 'should be a String');
+  });
+
+  it("does nothing if the field is not present", function() {
+    var user = new InstanceUser();
+    expect(user.isValid()).to.be(true);
+  });
+
+  it("does nothing if the field is the right type", function() {
+    var user = new InstanceUser({email: 'test@gmail.com'});
+    expect(user.isValid()).to.be(true);
+  });
+});
+
 describe("format", function() {
   var FormatUser = modella('user').attr('email', { format: /\w+@\w+\.com/ });
   FormatUser.use(validators);


### PR DESCRIPTION
``` js
var User = modella('user').attr('email', {type:String});
```

This change allows us to use a constructor function instead of a string for `type`, as a stepping stone toward modella/modella#24. It doesn't break the existing use of `type`, just adds another validator.

It won't validate a model instance yet, because clone ([lib/utils/clone:30](https://github.com/modella/modella/blob/master/lib/utils/clone.js#L30)) but I think we can opt out of cloning as for BSON ObjectIDs?
