### PR TITLE
fix for when a required field is boolean type

### DIFF
--- a/lib/required.js
+++ b/lib/required.js
@@ -1,7 +1,9 @@
 module.exports = function required(attr) {
   return function(Model){
     Model.validate(function(model){
-      if (!model.has(attr) || !model[attr]()) model.error(attr, 'field required');
+      if (!model.has(attr) || (typeof model[attr]() !== 'boolean' && !model[attr]())) {
+        model.error(attr, 'field required');
+      }
     });
   };
 }

--- a/test/validator_test.js
+++ b/test/validator_test.js
@@ -45,6 +45,22 @@ describe("required", function() {
     var user = new RequiredUser({email: 'test@gmail.com'});
     expect(user.isValid()).to.be(true);
   });
+
+  var RequiredUserWithBool = modella('user')
+  .attr('email', { required: true })
+  .attr('alive', { required: true, type: 'boolean' });
+  RequiredUserWithBool.use(validators);
+
+  it("allows required boolean field that is true", function() {
+    RequiredUserWithBool.use(validators);
+    var user = new RequiredUserWithBool({email: 'test@gmail.com', alive: true});
+    expect(user.isValid()).to.be(true);
+  });
+
+  it("allows required boolean field that is false", function() {
+    var user = new RequiredUserWithBool({email: 'test@gmail.com', alive: false});
+    expect(user.isValid()).to.be(true);
+  });
 });
 
 describe("confirms", function() {


### PR DESCRIPTION
- before this change a required boolean field with a false value would
  not validate properly. This patch uses a guard to test for the field
  being a boolean type in the required validator function.
- also adds tests for a model with a required boolean field.

closes #8
